### PR TITLE
Remove not necessary settings in template

### DIFF
--- a/Wizard for NagiosXI/ibmiservice/templates/ibmiservice.cfg
+++ b/Wizard for NagiosXI/ibmiservice/templates/ibmiservice.cfg
@@ -3,17 +3,7 @@
 #########################################
 define host {
     name                    IBM-i               ; The name of this host template
-    use                     generic-host        ; This template inherits other values from the generic-host template
-    check_period            24x7                ; By default, Linux hosts are checked round the clock
-    check_interval          5                   ; Actively check the host every 5 minutes
-    retry_interval          1                   ; Schedule host check retries at 1 minute intervals
-    max_check_attempts      10                  ; Check each Linux host 10 times (max)
-    check_command           check-host-alive
-    notification_period     24x7				; 
-                                                ; Note that the notification_period variable is being overridden from
-                                                ; the value that is inherited from the generic-host template!
-    notification_interval   120             	; Resend notifications every 2 hours
-    notification_options    d,u,r           	; Only send notifications for specific host states
+    use                     xiwizard_generic_host        ; This template inherits other values from the generic-host template
     register                0               	; DONT REGISTER THIS DEFINITION - ITS NOT A REAL HOST, JUST A TEMPLATE!
 }
 


### PR DESCRIPTION
Remove other not necessary settings in template to make it more usable by all Nagios XI Wizard users using their settings for hosts.